### PR TITLE
fix for `[hash]` not being replaced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 .eslintcache
 target/
 *.stackdump
+.env

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+//npm.pkg.github.com/:_authToken=$NPM_CONFIG_TOKEN
+@wunderlins:registry=https://npm.pkg.github.com
+always-auth=true

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function (options) {
                                     value = value.replace(publicPath, '');
                                 }
 
-                                let pattern = new RegExp(`^${value.replace('[hash]', '([a-f0-9]+)')}$`);
+                                let pattern = new RegExp(`^${value.replace('[hash]', '([a-zA-Z0-9]+)')}$`);
                                 let file = findMatchingFile(pattern, bundle);
 
                                 if (file) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "rollup-plugin-static-files",
+  "name": "@wunderlins/rollup-plugin-static-files",
   "description": "Copies static files into output directory with support for hash replacement.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "index.js",
   "author": "Paul Sweeney",
   "license": "MIT",
@@ -9,5 +9,12 @@
     "cheerio": "^1.0.0-rc.2",
     "fs-extra": "^7.0.1",
     "klaw-sync": "^6.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wunderlins/rollup-plugin-static-files"
+  },
+  "publishConfig": {
+    "@wunderlins:registry": "https://npm.pkg.github.com"
   }
 }


### PR DESCRIPTION
I am using `rollup` version `4.6.0`.  My output configuration looks like this

```javascript
{

    output: [
        {
            dir: './dist',
            format: 'iife',
            name: 'app',
            sourcemap: true,
            entryFileNames: '[name].[hash].js',
            assetFileNames: '[name].[hash][extname]',
            plugins: [terser()]
        }
    ],

}
```

when I build my project, the static files are renamed as expected. however the hash uses alpha numeric characters (upper and lower case and not just hex). So in index.html, my `[hash]` place holder gets never found.

So in my index.html the following line remains:
```html
<script async="" src="main.[hash].js"></script>
```
instead of:
```html
<script async="" src="main.OjLZVLNa.js"></script>
```

With a small change in the regex i got it fixed: https://github.com/PepsRyuu/rollup-plugin-static-files/commit/366baf232191cd5b99fd27ee654f0d83000163a9#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346

Until the original author fixes this behaviour, a fixed release with version `0.2.1` has been published as npm packages and can be isntalled with 

```bash
$ npm install @wunderlins/rollup-plugin-static-files@0.2.1
```
